### PR TITLE
nwb should be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/stephenwf/create-nwb-webpack-config/issues"
   },
   "homepage": "https://github.com/stephenwf/create-nwb-webpack-config#readme",
-  "dependencies": {
-    "nwb": "^0.19.1"
+  "peerDependencies": {
+    "nwb": "^0.22.0"
   }
 }


### PR DESCRIPTION
there's no reason to have a nested dependency of `nwb` since the only use case for this module requires that the developer be using `nwb` already